### PR TITLE
Support specifying rosbag with environment variables

### DIFF
--- a/player.launch
+++ b/player.launch
@@ -4,7 +4,7 @@
     <param name="use_sim_time" value="true"/>
 
     <!-- Configurations -->
-    <arg name="path_to_rosbag" default="" />
+    <arg name="path_to_rosbag" default="$(optenv PATH_TO_ROSBAG)" />
     <arg name="graceful_time" default="5" />
     <arg name="timeout" default="60" />
     <arg name="websocket_external_port" default="None" />


### PR DESCRIPTION
## What?
Add `optenv` to `player.launch`

## Why?
To improve usability