### PR TITLE
Support specifying websocket port with env

### DIFF
--- a/player.launch
+++ b/player.launch
@@ -7,7 +7,7 @@
     <arg name="path_to_rosbag" default="$(optenv PATH_TO_ROSBAG)" />
     <arg name="graceful_time" default="5" />
     <arg name="timeout" default="60" />
-    <arg name="websocket_external_port" default="None" />
+    <arg name="websocket_external_port" default="$(optenv WEBSOCKET_EXTERNAL_PORT None)" />
 
     <!-- Rosbridge-server -->
     <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch">


### PR DESCRIPTION
## What?
Specify `websocket_external_port` with environment variable `WEBSOCKET_EXTERNAL_PORT`

## Why?
To improve usability